### PR TITLE
v0.2.3 - Refactor Functor typing and Objekt

### DIFF
--- a/__tests__/map.ts
+++ b/__tests__/map.ts
@@ -1,5 +1,4 @@
-import { map } from '../source'
-import { Functor } from '../source/map'
+import { Functor, map } from '../source'
 
 test('map returns input if function not provided', () => {
   const input = { foo: 'bar' }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rpearce/ts-fns",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "",
   "author": "Robert Pearce <me@robertwpearce.com> (https://robertwpearce.com)",
   "license": "Unlicense",

--- a/source/customTypes.ts
+++ b/source/customTypes.ts
@@ -1,0 +1,12 @@
+export type Key =
+    string
+  | number
+  | symbol
+
+export type Objekt<A> =
+  Record<Key, A>
+
+export type Functor<A> =
+  { map<B>(fn: (x: A) => B): Functor<B>
+  , [k: Key]: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  }

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,4 +1,5 @@
 export { F } from './F'
+export { Functor, Key, Objekt } from './customTypes'
 export { T } from './T'
 export { compose2 } from './compose2'
 export { compose3 } from './compose3'

--- a/source/isFunctor.ts
+++ b/source/isFunctor.ts
@@ -1,8 +1,4 @@
-import { isArray, isObject, isFunction } from './'
+import { Functor, isArray, isObject, isFunction } from './'
 
-export interface IsFunctor {
-  (x: unknown): boolean
-}
-
-export const isFunctor: IsFunctor = x =>
+export const isFunctor = <A>(x: unknown): x is Functor<A> =>
   (isArray(x) || isObject(x)) && isFunction(x.map)

--- a/source/isObject.ts
+++ b/source/isObject.ts
@@ -1,4 +1,4 @@
-type K = string | number | symbol
+import { Objekt } from './'
 
-export const isObject = (x: unknown): x is Record<K, unknown> =>
+export const isObject = (x: unknown): x is Objekt<unknown> =>
   !!x && Object.prototype.toString.call(x) === '[object Object]'

--- a/source/map.ts
+++ b/source/map.ts
@@ -1,4 +1,6 @@
 import {
+  Functor,
+  Objekt,
   compose2,
   isFunction,
   isFunctor,
@@ -6,31 +8,23 @@ import {
   mapObject,
 } from './'
 
-export type K = string | number | symbol
-
-export interface Functor<A> {
-  map<B>(fn: (x: A) => B): Functor<B>,
-  [k: K]: any, // eslint-disable-line @typescript-eslint/no-explicit-any
-}
-
-export interface Funxion {
-  <A, B>(x: A): B
-}
-
-export type MapData<A> = Functor<A> | Record<K, A> | Funxion
+export type MapData<A> =
+    Functor<A>
+  | Objekt<A>
+  | ((x: unknown) => A)
 
 export const map = <A, B>(fn: (x: A) => B) => (m: MapData<A>) => {
   if (isFunction(fn)) {
     if (isFunctor(m)) {
-      return (m as Functor<A>).map(fn)
+      return m.map(fn)
     }
 
     if (isObject(m)) {
-      return mapObject(fn)(m as Record<K, A>)
+      return mapObject(fn)(m)
     }
 
     if (isFunction(m)) {
-      return compose2(fn, m as Funxion)
+      return compose2(fn, m)
     }
   }
 

--- a/source/mapObject.ts
+++ b/source/mapObject.ts
@@ -1,7 +1,7 @@
-type K = string | number | symbol
+import { Objekt } from './'
 
-export const mapObject = <A, B>(fn: (x: A) => B) => (obj: Record<K, A>) => {
-  const newObj = {} as Record<K, B>
+export const mapObject = <A, B>(fn: (x: A) => B) => (obj: Objekt<A>) => {
+  const newObj = {} as Objekt<B>
 
   for (const k in obj) {
     newObj[k] = fn(obj[k])

--- a/source/propOr.ts
+++ b/source/propOr.ts
@@ -1,4 +1,4 @@
-type Key = string | number | symbol
+import { Key } from './'
 
 export interface PropOr {
   <A>(fallback: A):


### PR DESCRIPTION
Significantly simplifies the `map`'s typing implementation by moving `Functor` and `Objekt` type construction to their respective `if*` places.

Also makes sure ot export some of these typings we're using -- everything is available at the top level.