### PR TITLE
feat: add classNames

### DIFF
--- a/__tests__/classNames.ts
+++ b/__tests__/classNames.ts
@@ -1,0 +1,21 @@
+import { classNames } from '../source'
+
+test('cond works will all static values', () => {
+  expect(classNames()).toStrictEqual('')
+  expect(classNames('')).toStrictEqual('')
+  expect(classNames('foo')).toStrictEqual('foo')
+  expect(classNames('foo bar')).toStrictEqual('foo bar')
+  expect(classNames('foo', 'bar')).toStrictEqual('foo bar')
+  expect(classNames('foo', 'bar', 'baz')).toStrictEqual('foo bar baz')
+  expect(classNames('foo', { 'bar': true })).toStrictEqual('foo bar')
+  expect(classNames('foo', { 'bar': true, 'baz': false })).toStrictEqual('foo bar')
+  expect(classNames('foo', { 'bar': true, 'baz': true })).toStrictEqual('foo bar baz')
+  expect(classNames('foo', { 'bar': true, 'baz': true }, 'qux')).toStrictEqual('foo bar baz qux')
+  expect(classNames('foo', { 'bar': true, 'baz': true }, 'qux', {})).toStrictEqual('foo bar baz qux')
+  expect(classNames('foo', { 'bar': true, 'baz': true }, 'qux', { 'abc': false })).toStrictEqual('foo bar baz qux')
+  expect(classNames('foo', { 'bar': true, 'baz': true }, 'qux', { 'abc': true })).toStrictEqual('foo bar baz qux abc')
+  expect(classNames({ 'bar': true, 'baz': false, 'qux': true })).toStrictEqual('bar qux')
+
+  // @ts-expect-error Testing undefined behavior for non-TS
+  expect(classNames(undefined, 'foo')).toStrictEqual('foo')
+})

--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -4,6 +4,7 @@ test('all exports are defined', () => {
   const expectedFns = [
     'F',
     'T',
+    'classNames',
     'compose2',
     'compose3',
     'cond',

--- a/source/classNames.ts
+++ b/source/classNames.ts
@@ -1,0 +1,23 @@
+import { isObject } from './'
+
+export interface ClassNames {
+  (...args: (string | Record<string, boolean>)[]): string
+}
+
+export const classNames: ClassNames = (...args) => {
+  const cns: string[] = []
+
+  for (const arg of args) {
+    if (typeof arg === 'string') {
+      cns.push(arg)
+    } else if (isObject(arg)) {
+      for (const k in arg) {
+        if (arg[k]) {
+          cns.push(k)
+        }
+      }
+    }
+  }
+
+  return cns.join(' ')
+}

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,6 +1,7 @@
 export { F } from './F'
 export { Functor } from './customTypes'
 export { T } from './T'
+export { classNames } from './classNames'
 export { compose2 } from './compose2'
 export { compose3 } from './compose3'
 export { cond, condU } from './cond'


### PR DESCRIPTION
An implementation of the `classNames` concept. I initially did this with only a single object API,

```ts
classNames({
  'foo': true,
  'bar': false,
  'baz': true,
})
```

but this is a popular enough concept that allowing a variadic mix of objects and strings seemed reasonable enough to allow.